### PR TITLE
enhance(config): use the crate's version as the cli's version

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 /// A tool for quickly collecting function selectors and decoding signatures from on-chain EVM bytecode.
 #[derive(Parser, Debug, Serialize)]
-#[clap(version = "0.2.0", author = "wavefnx @wavefnx")]
+#[clap(version = crate::VERSION, author = "wavefnx @wavefnx")]
 #[clap(group(ArgGroup::new("input").args(&["address", "file"]).required(true)))]
 pub struct Config {
     /// Export the signatures as a JSON file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_RPC_URL: &str = "https://ethereum-rpc.publicnode.com";
 
 pub mod config;


### PR DESCRIPTION
# Use the crate's version in the CLI

## Overview
Utilize the `CARGO_PKG_VERSION` env variable provided by cargo to set the CLI's version since for now, it's all one package

## Dev features
- The version will now have to be set once in `Cargo.toml` which will simplify potential future `CI` builds

## Files changed
- `src/lib.rs`: Global internal `VERSION` const
- `src/config.rs`: The CLI will now use the crates version