### PR TITLE
Wavefnx/v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "sigmund"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigmund"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["wavefnx @wavefnx"]
 description = "A tool for collecting function selectors and decoding signatures from on-chain EVM bytecode."

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Options:
       --signatures         Collect all known function signatures from the contract's selectors
       --address <ADDRESS>  The address of the EVM contract
   -f, --file <FILE>        Path to a local file containing the contract's bytecode
+      --deep               Collect all four-byte pushes (fn, err, ...), including non-selectors
       --all-matches        Return all available signature matches for each selector
       --rpc-url <RPC_URL>  To use your own Node or collect bytecode from a different network, provide the relevant RPC URL [default: https://ethereum-rpc.publicnode.com]
   -h, --help               Print help

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Options:
       --signatures         Collect all known function signatures from the contract's selectors
       --address <ADDRESS>  The address of the EVM contract
   -f, --file <FILE>        Path to a local file containing the contract's bytecode
-      --most-common        Return only the signatures with the highest probability of being correct
+      --all-matches        Return all available signature matches for each selector
       --rpc-url <RPC_URL>  To use your own Node or collect bytecode from a different network, provide the relevant RPC URL [default: https://ethereum-rpc.publicnode.com]
   -h, --help               Print help
   -V, --version            Print version

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A tool for quickly collecting function selectors and decoding signatures from on
 Usage: sigmund [OPTIONS] <--address <ADDRESS>|--file <FILE>>
 
 Options:
-  -o, --output <OUTPUT>    Export the signatures as a JSON file
+  -o, --output <OUTPUT>    Path to export the signatures as a JSON file
       --signatures         Collect all known function signatures from the contract's selectors
       --address <ADDRESS>  The address of the EVM contract
   -f, --file <FILE>        Path to a local file containing the contract's bytecode

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -7,32 +7,42 @@ pub struct Bytecode {
 }
 
 impl Bytecode {
-    /// Finds function selectors within the bytecode.
+    /// Find selectors in the bytecode.
     ///
-    /// Scan the bytecode for specific patterns that correspond to
-    /// the start of function selectors. It returns a set of found selectors
-    /// as hexadecimal strings.
-    /// ```rs
-    /// JUMPI (0x57)
-    /// DUP1  (0x80)
-    /// PUSH4 (0x63)
-    /// ```
+    /// The bytecode pattern `PUSH4 <selector> EQ` usually occus at the initialization of the code where
+    /// the function selectors are compared to the input calldata to determine the byte offset
+    /// of the function to be executed.
+    ///
     /// Returns:
     /// A `HashSet<String>` containing the unique hexadecimal function selectors found in the bytecode.
+    ///
+    /// The exact steps depend on the compiler and version, although the general pattern is:
+    /// ```rs
+    /// // 1. Extract the function selector from the calldata and push in the stack. (mask,shr, ...)
+    /// // 2. Duplicate the selector (to be consumed by `EQ`)
+    /// DUP1
+    /// // 3. Push the function selector to compare against
+    /// PUSH4 <selector>
+    /// // 4. Compare the two selectors, push 1 if equal, 0 otherwise
+    /// EQ
+    /// // 5. Push the jump destination if the selectors match
+    /// PUSH2 <offset>
+    /// // 6. Jump to <offset> if the result of `EQ` is 1
+    /// JUMPI
+    /// ```
     #[inline]
     pub fn find_function_selectors(&self) -> HashSet<String> {
-        self.inner
-            .windows(7)
-            .filter_map(|window| {
-                // Check if the window starts with the specific pattern
-                if window.starts_with(&[0x57, 0x80, 0x63]) {
-                    // If yes, extract the next 4 bytes as the selector
-                    Some(hex::encode(&window[3..7]))
-                } else {
-                    None
-                }
-            })
-            .collect()
+        let mut selectors = HashSet::new();
+        let selector_size = 5;
+
+        for idx in 0..self.inner.len().saturating_sub(selector_size) {
+            // since we use `saturating_sub(pattern_length)` the next `pattern_length` bytes will be available
+            if self.inner[idx] == 0x63 && self.inner[idx + selector_size] == 0x14 {
+                selectors.insert(hex::encode(&self.inner[idx + 1..idx + selector_size]));
+            }
+        }
+
+        selectors
     }
 }
 

--- a/src/bytecode.rs
+++ b/src/bytecode.rs
@@ -31,13 +31,13 @@ impl Bytecode {
     /// JUMPI
     /// ```
     #[inline]
-    pub fn find_function_selectors(&self) -> HashSet<String> {
+    pub fn find_function_selectors(&self, deep: bool) -> HashSet<String> {
         let mut selectors = HashSet::new();
         let selector_size = 5;
 
         for idx in 0..self.inner.len().saturating_sub(selector_size) {
             // since we use `saturating_sub(pattern_length)` the next `pattern_length` bytes will be available
-            if self.inner[idx] == 0x63 && self.inner[idx + selector_size] == 0x14 {
+            if self.inner[idx] == 0x63 && (deep || self.inner[idx + selector_size] == 0x14) {
                 selectors.insert(hex::encode(&self.inner[idx + 1..idx + selector_size]));
             }
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -127,7 +127,7 @@ impl Client {
             match most_common {
                 // The first item will always exist since successful responses always contain at least one signature or return 404,
                 // additionally, the current API returns signatures ordered by the ones that are encountered the most.
-                // 
+                //
                 // Both of these cases are API specific and should be managed when the `SignatureProvider` trait is implemented.
                 true => response.items.into_iter().for_each(|item| signatures.push(Signature::from(item))),
                 false => signatures.push(Signature::from(response.items.first().unwrap_or(&SignatureItem::default()))),

--- a/src/client.rs
+++ b/src/client.rs
@@ -125,9 +125,10 @@ impl Client {
 
         for response in successful {
             match most_common {
-                // #![INFO]: the first item will always exist since successful responses always contain at least one
-                // Additionally, the current API returns responses ordered by the highest count.
-                // When we switch to a `SignatureProvider` trait, this should be handled there.
+                // The first item will always exist since successful responses always contain at least one signature or return 404,
+                // additionally, the current API returns signatures ordered by the ones that are encountered the most.
+                // 
+                // Both of these cases are API specific and should be managed when the `SignatureProvider` trait is implemented.
                 true => response.items.into_iter().for_each(|item| signatures.push(Signature::from(item))),
                 false => signatures.push(Signature::from(response.items.first().unwrap_or(&SignatureItem::default()))),
             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -128,8 +128,8 @@ impl Client {
                 // #![INFO]: the first item will always exist since successful responses always contain at least one
                 // Additionally, the current API returns responses ordered by the highest count.
                 // When we switch to a `SignatureProvider` trait, this should be handled there.
-                true => signatures.push(Signature::from(response.items.first().unwrap_or(&SignatureItem::default()))),
-                false => response.items.into_iter().for_each(|item| signatures.push(Signature::from(item))),
+                true => response.items.into_iter().for_each(|item| signatures.push(Signature::from(item))),
+                false => signatures.push(Signature::from(response.items.first().unwrap_or(&SignatureItem::default()))),
             }
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,10 @@ pub struct Config {
     #[clap(short = 'f', long, value_parser)]
     pub file: Option<PathBuf>,
 
+    /// Collect all four-byte pushes (fn, err, ...), including non-selectors
+    #[clap(long, action = clap::ArgAction::SetTrue)]
+    pub deep: bool,
+
     /// Return all available signature matches for each selector
     #[clap(long, action = clap::ArgAction::SetTrue, requires = "signatures")]
     pub all_matches: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,9 +23,9 @@ pub struct Config {
     #[clap(short = 'f', long, value_parser)]
     pub file: Option<PathBuf>,
 
-    /// Return only the signatures with the highest probability of being correct
+    /// Return all available signature matches for each selector
     #[clap(long, action = clap::ArgAction::SetTrue, requires = "signatures")]
-    pub most_common: bool,
+    pub all_matches: bool,
 
     /// To use your own Node or collect bytecode from a different network, provide the relevant RPC URL.
     #[clap(long, default_value = crate::DEFAULT_RPC_URL)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 #[clap(version = crate::VERSION, author = "wavefnx @wavefnx")]
 #[clap(group(ArgGroup::new("input").args(&["address", "file"]).required(true)))]
 pub struct Config {
-    /// Export the signatures as a JSON file
+    /// Path to export the signatures as a JSON file
     #[clap(short = 'o', long, value_parser)]
     pub output: Option<PathBuf>,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ impl Sigmund {
 
         let signatures = if self.config.signatures {
             // Collect all signatures that exist in the database
-            let signatures = self.client.get_signatures(&selectors, self.config.most_common).await;
+            let signatures = self.client.get_signatures(&selectors, self.config.all_matches).await;
             let signatures = signatures.map_err(|e| e.to_string())?;
             // Print the formatted signatures to the console
             signatures.iter().for_each(|s| println!("{}", s));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ impl Sigmund {
         // Get the bytecode from the specified source
         let bytecode = self.get_bytecode().await.map_err(|e| e.to_string())?;
         // Extract function selectors from the bytecode
-        let selectors = bytecode.find_function_selectors();
+        let selectors = bytecode.find_function_selectors(self.config.deep);
 
         let signatures = if self.config.signatures {
             // Collect all signatures that exist in the database

--- a/tests/bytecode.rs
+++ b/tests/bytecode.rs
@@ -16,18 +16,17 @@ fn it_fails_to_create_bytecode_from_invalid_input() {
 
 #[test]
 fn it_finds_function_signatures() {
-    let hex_with_signatures = "0x578063340a95345780636c5f90bb".to_string();
+    let hex_with_signatures = "0xe01c63ddc632621461".to_string();
     let bytecode = Bytecode::try_from(hex_with_signatures).unwrap();
-    let signatures = bytecode.find_function_selectors();
-    assert_eq!(signatures.len(), 2);
-    assert!(signatures.contains("340a9534"));
-    assert!(signatures.contains("6c5f90bb"));
+    let signatures = bytecode.find_function_selectors(false);
+    assert_eq!(signatures.len(), 1);
+    assert!(signatures.contains("ddc63262"));
 }
 
 #[test]
 fn it_does_not_find_signatures_when_none_exist() {
     let hex_no_signatures = "0x12345678".to_string();
     let bytecode = Bytecode::try_from(hex_no_signatures).unwrap();
-    let signatures = bytecode.find_function_selectors();
+    let signatures = bytecode.find_function_selectors(false);
     assert!(signatures.is_empty());
 }


### PR DESCRIPTION
# Sigmund v0.2.1

## Description
Improved opcode pattern matching, more intuitive interface and defaults and a new `--deep` flag option.

## User Features 
- new `--deep` flag to allow the collection of **all** four-byte pushes, mostly for analysis.
- improved UX with most common matches showing by default, the `--all-matches` flag is optional and shows all signatures matches for a selector.

## File changes
- `/tests/bytecode.rs`: tests to reflect the new opcode pattern matching
- `/src/bytecode.rs`: updated opcode pattern matching, use of the `--deep` flag 
- `src/client.rs`: default to return most common signatures, updated comments
- `src/config.rs`: new `--deep` flag, replaced `--most-common` with `--all-matches` as default.
- `src/lib.rs`: use the `--deep` flag in the Sigmund 🗿 struct
- `README.md`: Update Readme to follow the new interface with examples